### PR TITLE
fix: swap interval and repetitions docstring descriptions in sm2()

### DIFF
--- a/spacedreppy/schedulers/sm2.py
+++ b/spacedreppy/schedulers/sm2.py
@@ -8,8 +8,8 @@ def sm2(quality: int, interval: int, repetitions: int, easiness: float) -> tuple
 
     Args:
         quality: A performance measure ranging 0 (complete blackout) to 5 (perfect response).
-        interval: The number of consecutive correct answers (quality >= 3).
-        repetitions: Inter-repetition interval after the n-th repetition (in days).
+        interval: Inter-repetition interval after the n-th repetition (in days).
+        repetitions: The number of consecutive correct answers (quality >= 3).
         easiness: Easiness factor reflecting the easiness of memorizing and retaining a given item in memory.
 
     Returns:


### PR DESCRIPTION
The docstring for the `interval` and `repetitions` parameters in `sm2()` were swapped.

- `interval` is the inter-repetition interval in days
- `repetitions` is the number of consecutive correct answers (quality >= 3)

This commit corrects them.