### PR TITLE
fix: correct coverage.py configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,14 +102,9 @@ addopts = [
 ]
 
 [tool.coverage.run]
-source = ["tests"]
-
-[coverage.paths]
-source = "spacedreppy"
-
-[coverage.run]
+source = ["spacedreppy"]
 branch = true
 
-[coverage.report]
+[tool.coverage.report]
 fail_under = 50
 show_missing = true


### PR DESCRIPTION
Fixes three issues with the coverage.py configuration:

1. **Wrong source**: `source = [tests]` measured coverage of test files instead of library code. Changed to `[spacedreppy]`.
2. **Missing `tool.` prefix**: `[coverage.run]` and `[coverage.report]` tables were silently ignored by coverage.py because they need the `[tool.coverage.*]` prefix in pyproject.toml. Consolidated into `[tool.coverage.run]` and `[tool.coverage.report]`.
3. **Redundant section**: Removed `[coverage.paths]` which duplicated the source path and was also missing the `tool.` prefix.