### PR TITLE
fix: prevent interval type mutation from int to timedelta

### DIFF
--- a/spacedreppy/schedulers/spaced_repetition_scheduler.py
+++ b/spacedreppy/schedulers/spaced_repetition_scheduler.py
@@ -12,9 +12,7 @@ class SpacedRepetitionScheduler:
         self, attempted_at: datetime, result: Any
     ) -> tuple[datetime, timedelta]:
         """Calculate the next due timestamp and interval."""
-        self.due_timestamp, self.interval_td = self._compute_next_due_interval(
-            attempted_at, result
-        )
+        self.due_timestamp, self.interval_td = self._compute_next_due_interval(attempted_at, result)
         return self.due_timestamp, self.interval_td
 
     def _compute_next_due_interval(

--- a/spacedreppy/schedulers/spaced_repetition_scheduler.py
+++ b/spacedreppy/schedulers/spaced_repetition_scheduler.py
@@ -5,14 +5,17 @@ from typing import Any, Optional
 class SpacedRepetitionScheduler:
     def __init__(self, interval):
         self.interval = interval
+        self.interval_td: Optional[timedelta] = None
         self.due_timestamp: Optional[datetime] = None
 
     def compute_next_due_interval(
         self, attempted_at: datetime, result: Any
     ) -> tuple[datetime, timedelta]:
         """Calculate the next due timestamp and interval."""
-        self.due_timestamp, self.interval = self._compute_next_due_interval(attempted_at, result)
-        return self.due_timestamp, self.interval
+        self.due_timestamp, self.interval_td = self._compute_next_due_interval(
+            attempted_at, result
+        )
+        return self.due_timestamp, self.interval_td
 
     def _compute_next_due_interval(
         self, attempted_at: datetime, result: Any


### PR DESCRIPTION
### Bug

`compute_next_due_interval` in `SpacedRepetitionScheduler` was assigning the returned `timedelta` back to `self.interval`, which is originally an `int` (days) used by the SM-2 algorithm. On the 3rd+ call — when `repetitions >= 2` and `quality >= 3` — `sm2()` executes `round(interval * easiness)` with a `timedelta` instead of an `int`, raising a `TypeError`.

The existing tests never caught this because they only called `compute_next_due_interval` at most twice, never reaching the `repetitions >= 2` code path.

### Fix

Store the `timedelta` in a new `self.interval_td` attribute instead of overwriting `self.interval`. This keeps `self.interval` as the `int` that SM-2 expects while still exposing the `timedelta` for callers.

### Tests

Added `test_sm2_scheduler_compute_next_due_interval_thrice` — a parametrized regression test that exercises 3 consecutive scheduler calls with various quality sequences, including cases that reach `repetitions >= 2` with `quality >= 3`. Also asserts that `scheduler.interval` remains an `int` after all calls.