### PR TITLE
chore: update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,8 @@
-default_language_version:
-  python: python3.9
-
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: check-yaml
@@ -15,32 +12,15 @@ repos:
       - id: end-of-file-fixer
         exclude: LICENSE
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
     hooks:
-      - id: pyupgrade
-        name: pyupgrade
-        entry: poetry run pyupgrade --py39-plus
-        types: [ python ]
-        language: system
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 
-  - repo: local
+  - repo: https://github.com/asottile/blacken-docs
+    rev: 1.20.0
     hooks:
-      - id: isort
-        name: isort
-        entry: poetry run isort --settings-path pyproject.toml
-        types: [python]
-        language: system
-
-  - repo: local
-    hooks:
-      - id: black
-        name: black
-        entry: poetry run black --config pyproject.toml
-        types: [ python ]
-        language: system
-
-  -   repo: https://github.com/asottile/blacken-docs
-      rev: v1.12.0
-      hooks:
-        -   id: blacken-docs
-            additional_dependencies: [black==21.12b0]
+      - id: blacken-docs
+        additional_dependencies: [black]


### PR DESCRIPTION
## Changes

- **pre-commit-hooks**: v2.5.0 → v6.0.0
- **Replace local hooks** (pyupgrade, isort, black via \poetry run\) with **ruff-pre-commit v0.15.4** — ruff handles linting, import sorting, and formatting
- **blacken-docs**: v1.12.0 → 1.20.0, updated pinned black dependency
- Removed stale \default_language_version: python3.9\
- Removed all \poetry run\ references (project uses hatchling)