### PR TITLE
chore: polish public API, tests, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,15 @@
 
 # SpacedRepPy
 
-<div style="text-align: center">
-
 [![Build status](https://github.com/lschlessinger1/spacedreppy/workflows/build/badge.svg?branch=main&event=push)](https://github.com/lschlessinger1/spacedreppy/actions?query=workflow%3Abuild)
 [![Python Version](https://img.shields.io/pypi/pyversions/spacedreppy.svg)](https://pypi.org/project/spacedreppy/)
-[![Dependencies Status](https://img.shields.io/badge/dependencies-up%20to%20date-brightgreen.svg)](https://github.com/lschlessinger1/spacedreppy/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Aapp%2Fdependabot)
-
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![License](https://img.shields.io/github/license/lschlessinger1/spacedreppy)](https://github.com/lschlessinger1/spacedreppy/blob/main/LICENSE)
+[![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Security: bandit](https://img.shields.io/badge/security-bandit-green.svg)](https://github.com/PyCQA/bandit)
 [![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/lschlessinger1/spacedreppy/blob/main/.pre-commit-config.yaml)
-[![Semantic Versions](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--versions-e10079.svg)](https://github.com/lschlessinger1/spacedreppy/releases)
-[![License](https://img.shields.io/github/license/lschlessinger1/spacedreppy)](https://github.com/lschlessinger1/spacedreppy/blob/main/LICENSE)
 ![Coverage Report](assets/images/coverage.svg)
 
 A spaced repetition Python library.
-
-</div>
 
 ## Installation
 
@@ -31,14 +24,46 @@ pip install spacedreppy
 ## Usage
 
 ```python
-from datetime import datetime
-from spacedreppy.schedulers.sm2 import SM2Scheduler
+from datetime import datetime, timezone
+from spacedreppy import SM2Scheduler
 
-# returns next due timestamp and next interval.
 scheduler = SM2Scheduler()
+
+# Each call returns the next due timestamp and interval.
 due_timestamp, interval = scheduler.compute_next_due_interval(
-    attempted_at=datetime.utcnow(), result=3
+    attempted_at=datetime.now(timezone.utc), result=4
 )
+```
+
+The `result` parameter is a quality score from the SM-2 algorithm:
+
+| Score | Meaning |
+|-------|---------|
+| 0 | Complete blackout — no recall at all |
+| 1 | Incorrect response, but the correct answer seemed easy to recall once seen |
+| 2 | Incorrect response, but the correct answer was remembered upon seeing it |
+| 3 | Correct response with serious difficulty |
+| 4 | Correct response after some hesitation |
+| 5 | Perfect response with no hesitation |
+
+Scores of 3 or higher count as correct and advance the repetition schedule. Scores below 3 reset the interval.
+
+## Development
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management and [just](https://github.com/casey/just) as a command runner.
+
+```bash
+# Install dependencies
+just install
+
+# Run tests
+just test
+
+# Run formatters
+just codestyle
+
+# Run all linting (tests + style + mypy + safety)
+just lint
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,25 @@ license = { text = "MIT" }
 readme = "README.md"
 keywords = ["Spaced-repetition"]
 requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Education",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/lschlessinger1/spacedreppy"
+Repository = "https://github.com/lschlessinger1/spacedreppy"
+Issues = "https://github.com/lschlessinger1/spacedreppy/issues"
 
 [dependency-groups]
 dev = [

--- a/spacedreppy/__init__.py
+++ b/spacedreppy/__init__.py
@@ -1,0 +1,9 @@
+"""SpacedRepPy — A spaced repetition Python library."""
+
+from importlib.metadata import version
+
+from spacedreppy.schedulers.sm2 import SM2Scheduler
+from spacedreppy.schedulers.spaced_repetition_scheduler import SpacedRepetitionScheduler
+
+__version__ = version("spacedreppy")
+__all__ = ["SM2Scheduler", "SpacedRepetitionScheduler", "__version__"]

--- a/spacedreppy/schedulers/__init__.py
+++ b/spacedreppy/schedulers/__init__.py
@@ -1,0 +1,6 @@
+"""Spaced repetition scheduler implementations."""
+
+from spacedreppy.schedulers.sm2 import SM2Scheduler
+from spacedreppy.schedulers.spaced_repetition_scheduler import SpacedRepetitionScheduler
+
+__all__ = ["SM2Scheduler", "SpacedRepetitionScheduler"]

--- a/tests/test_sm2.py
+++ b/tests/test_sm2.py
@@ -46,7 +46,7 @@ def test_sm2_update_once(quality, expected_repetitions):
         ((5, 3), 2, 6),
     ],
 )
-def test_SM2_update_params_twice(qualities, expected_repetitions, expected_interval):
+def test_sm2_update_params_twice(qualities, expected_repetitions, expected_interval):
     interval, repetitions, easiness = sm2(qualities[0], interval=0, repetitions=0, easiness=2.5)
     interval, repetitions, easiness = sm2(
         qualities[1], interval=interval, repetitions=repetitions, easiness=easiness
@@ -66,7 +66,7 @@ def test_SM2_update_params_twice(qualities, expected_repetitions, expected_inter
         ((5, 3, 5), 3, 15),
     ],
 )
-def test_SM2_update_thrice(qualities, expected_repetitions, expected_interval):
+def test_sm2_update_thrice(qualities, expected_repetitions, expected_interval):
     interval, repetitions, easiness = sm2(qualities[0], interval=0, repetitions=0, easiness=2.5)
     interval, repetitions, easiness = sm2(
         qualities[1], interval=interval, repetitions=repetitions, easiness=easiness
@@ -98,7 +98,7 @@ def test_sm2_scheduler_initialization(scheduler):
     ],
 )
 def test_sm2_scheduler_compute_next_due_interval_once(scheduler, quality, expected_repetitions):
-    attempted_at = datetime.datetime.utcnow()
+    attempted_at = datetime.datetime.now(datetime.timezone.utc)
     due_timestamp, interval = scheduler.compute_next_due_interval(
         attempted_at=attempted_at, result=quality
     )
@@ -195,3 +195,12 @@ def test_sm2_invalid_inputs(quality, interval, repetitions, easiness):
 def test_spaced_repetition_scheduler_is_abstract():
     with pytest.raises(TypeError):
         SpacedRepetitionScheduler(interval=0)
+
+
+def test_sm2_easiness_floor():
+    """Easiness should never drop below 1.3, even with the worst quality."""
+    _, _, easiness = sm2(quality=0, interval=0, repetitions=0, easiness=1.3)
+    assert easiness == 1.3
+
+    _, _, easiness = sm2(quality=0, interval=1, repetitions=1, easiness=1.4)
+    assert easiness >= 1.3


### PR DESCRIPTION
Covers the remaining improvements from the codebase review. Public API: populate __init__.py with re-exports, __all__, __version__. Packaging: add project.urls and project.classifiers to pyproject.toml. Tests: replace deprecated datetime.utcnow() with datetime.now(timezone.utc), fix inconsistent test naming (SM2 -> sm2), add easiness floor edge-case test. Docs: update README with SM-2 quality score table, development workflow section, ruff badge, remove non-rendering HTML div and stale badges.