### PR TITLE
ci: add PyPI publish workflow on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes to PyPI when a GitHub release is published.

Uses [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) via \pypa/gh-action-pypi-publish\ — no API tokens needed.

## Setup required

1. Go to [PyPI Trusted Publishers](https://pypi.org/manage/project/spacedreppy/settings/publishing/) and add a new publisher:
   - **Owner**: \lschlessinger1\
   - **Repository**: \spacedreppy\
   - **Workflow name**: \publish.yml\
   - **Environment**: \pypi\
2. Create a GitHub environment named \pypi\ in [repo settings](https://github.com/lschlessinger1/spacedreppy/settings/environments) (optional, for approval gates)