### PR TITLE
docs: add Leitner system to README and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-SpacedRepPy is a spaced repetition Python library implementing the SM-2 algorithm. It provides a scheduler abstraction (`SpacedRepetitionScheduler`) with a concrete SM-2 implementation (`SM2Scheduler`).
+SpacedRepPy is a spaced repetition Python library implementing the SM-2 and Leitner system algorithms. It provides a scheduler abstraction (`SpacedRepetitionScheduler`) with concrete implementations: `SM2Scheduler` and `LeitnerScheduler`.
 
 ## Tech Stack
 
@@ -28,7 +28,9 @@ SpacedRepPy is a spaced repetition Python library implementing the SM-2 algorith
 
 - `spacedreppy/schedulers/spaced_repetition_scheduler.py` — Abstract base class defining the scheduler interface.
 - `spacedreppy/schedulers/sm2.py` — SM-2 algorithm implementation and `SM2Scheduler` class.
-- `tests/test_sm2.py` — Test suite using pytest with parametrized tests.
+- `spacedreppy/schedulers/leitner.py` — Leitner system implementation and `LeitnerScheduler` class.
+- `tests/test_sm2.py` — SM-2 test suite using pytest with parametrized tests.
+- `tests/test_leitner.py` — Leitner test suite using pytest with parametrized tests.
 
 ## Development Workflow
 
@@ -45,4 +47,4 @@ just lint           # Run all checks (tests + style + mypy + safety)
 - All code must pass mypy in strict mode (see `[tool.mypy]` in `pyproject.toml`).
 - All code must pass ruff linting and formatting checks.
 - Tests use `pytest.mark.parametrize` extensively — follow this pattern for new tests.
-- Keep the SM-2 algorithm pure function (`sm2()`) separate from the scheduler class.
+- Keep algorithm pure functions (`sm2()`, `leitner()`) separate from their scheduler classes.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ pip install spacedreppy
 
 ## Usage
 
+### SM-2
+
 ```python
 from datetime import datetime, timezone
 from spacedreppy import SM2Scheduler
@@ -47,6 +49,33 @@ The `result` parameter is a quality score from the SM-2 algorithm:
 | 5 | Perfect response with no hesitation |
 
 Scores of 3 or higher count as correct and advance the repetition schedule. Scores below 3 reset the interval.
+
+### Leitner System
+
+```python
+from datetime import datetime, timezone
+from spacedreppy import LeitnerScheduler
+
+scheduler = LeitnerScheduler()
+
+# result=1 for correct, result=0 for incorrect
+due_timestamp, interval = scheduler.compute_next_due_interval(
+    attempted_at=datetime.now(timezone.utc), result=1
+)
+```
+
+The `result` parameter is a binary score:
+
+| Score | Meaning |
+|-------|---------|
+| 0 | Incorrect |
+| 1 | Correct |
+
+Correct answers promote the card to the next box; incorrect answers send it back to the first box. The default box intervals (in days) are `[1, 3, 7, 14, 30]`, but you can provide your own:
+
+```python
+scheduler = LeitnerScheduler(intervals=[2, 5, 10])
+```
 
 ## Development
 


### PR DESCRIPTION
The documentation only referenced SM-2 but the Leitner system is fully implemented and exported. This PR updates both files to include Leitner.

## Changes

### README.md
- Split Usage section into **SM-2** and **Leitner System** subsections
- Added Leitner usage example with `LeitnerScheduler`
- Added Leitner scoring table (0 = Incorrect, 1 = Correct)
- Documented box promotion/demotion behavior and default intervals
- Showed how to pass custom intervals

### .github/copilot-instructions.md
- Updated Project Overview to mention both SM-2 and Leitner
- Added `LeitnerScheduler` as a concrete implementation
- Added architecture entries for `leitner.py` and `test_leitner.py`
- Updated Key Practices to reference both `sm2()` and `leitner()` pure functions