### PR TITLE
fix: update build status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # SpacedRepPy
 
-[![Build status](https://github.com/lschlessinger1/spacedreppy/workflows/build/badge.svg?branch=main&event=push)](https://github.com/lschlessinger1/spacedreppy/actions?query=workflow%3Abuild)
+[![Build status](https://github.com/lschlessinger1/spacedreppy/actions/workflows/build.yml/badge.svg)](https://github.com/lschlessinger1/spacedreppy/actions/workflows/build.yml)
 [![Python Version](https://img.shields.io/pypi/pyversions/spacedreppy.svg)](https://pypi.org/project/spacedreppy/)
 [![License](https://img.shields.io/github/license/lschlessinger1/spacedreppy)](https://github.com/lschlessinger1/spacedreppy/blob/main/LICENSE)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## Summary
- Updated the build status badge in README.md from the old `/workflows/build/` URL format to `/actions/workflows/build.yml/`, which correctly shows the build status on the main page.

## Test plan
- [ ] Verify the badge on the PR preview shows the correct build status
- [ ] After merge, confirm the main repo page no longer shows "Build no status"

🤖 Generated with [Claude Code](https://claude.com/claude-code)