### PR TITLE
feat: implement FSRS-6 spaced repetition scheduler

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-SpacedRepPy is a spaced repetition Python library implementing the SM-2 and Leitner system algorithms. It provides a scheduler abstraction (`SpacedRepetitionScheduler`) with concrete implementations: `SM2Scheduler` and `LeitnerScheduler`.
+SpacedRepPy is a spaced repetition Python library implementing the SM-2, Leitner system, and FSRS-6 algorithms. It provides a scheduler abstraction (`SpacedRepetitionScheduler`) with concrete implementations: `SM2Scheduler`, `LeitnerScheduler`, and `FSRSScheduler`.
 
 ## Tech Stack
 
@@ -29,8 +29,10 @@ SpacedRepPy is a spaced repetition Python library implementing the SM-2 and Leit
 - `spacedreppy/schedulers/spaced_repetition_scheduler.py` — Abstract base class defining the scheduler interface.
 - `spacedreppy/schedulers/sm2.py` — SM-2 algorithm implementation and `SM2Scheduler` class.
 - `spacedreppy/schedulers/leitner.py` — Leitner system implementation and `LeitnerScheduler` class.
+- `spacedreppy/schedulers/fsrs.py` — FSRS-6 algorithm implementation and `FSRSScheduler` class.
 - `tests/test_sm2.py` — SM-2 test suite using pytest with parametrized tests.
 - `tests/test_leitner.py` — Leitner test suite using pytest with parametrized tests.
+- `tests/test_fsrs.py` — FSRS-6 test suite using pytest with parametrized tests.
 
 ## Development Workflow
 
@@ -47,4 +49,4 @@ just lint           # Run all checks (tests + style + mypy + safety)
 - All code must pass mypy in strict mode (see `[tool.mypy]` in `pyproject.toml`).
 - All code must pass ruff linting and formatting checks.
 - Tests use `pytest.mark.parametrize` extensively — follow this pattern for new tests.
-- Keep algorithm pure functions (`sm2()`, `leitner()`) separate from their scheduler classes.
+- Keep algorithm pure functions (`sm2()`, `leitner()`, `fsrs()`) separate from their scheduler classes.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,35 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+    paths: [pyproject.toml]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        run: gh release create "v${{ steps.version.outputs.version }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # SpacedRepPy
 
-A spaced repetition Python library implementing SM-2 and Leitner scheduling algorithms.
+A spaced repetition Python library implementing SM-2, Leitner, and FSRS-6 scheduling algorithms.
 
 ## Project Structure
 
-- `spacedreppy/schedulers/` - Core scheduler implementations (SM-2, Leitner, base class)
-- `tests/` - Test files (`test_sm2.py`, `test_leitner.py`)
+- `spacedreppy/schedulers/` - Core scheduler implementations (SM-2, Leitner, FSRS-6, base class)
+- `tests/` - Test files (`test_sm2.py`, `test_leitner.py`, `test_fsrs.py`)
 - `justfile` - Task runner commands
 - `pyproject.toml` - Project config, linting, typing, and test settings
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/lschlessinger1/spacedreppy/blob/main/.pre-commit-config.yaml)
 ![Coverage Report](assets/images/coverage.svg)
 
-A spaced repetition Python library.
+A spaced repetition Python library implementing SM-2, Leitner, and FSRS-6 algorithms.
 
 ## Installation
 
@@ -75,6 +75,44 @@ Correct answers promote the card to the next box; incorrect answers send it back
 
 ```python
 scheduler = LeitnerScheduler(intervals=[2, 5, 10])
+```
+
+### FSRS-6
+
+```python
+from datetime import datetime, timezone
+from spacedreppy import FSRSScheduler
+
+scheduler = FSRSScheduler()
+
+# result: 1=Again, 2=Hard, 3=Good, 4=Easy
+due_timestamp, interval = scheduler.compute_next_due_interval(
+    attempted_at=datetime.now(timezone.utc), result=3
+)
+```
+
+The `result` parameter is a rating from the FSRS algorithm:
+
+| Rating | Meaning |
+|--------|---------|
+| 1 (Again) | Forgot the card |
+| 2 (Hard) | Remembered with serious difficulty |
+| 3 (Good) | Remembered after some hesitation |
+| 4 (Easy) | Remembered easily |
+
+FSRS-6 models memory with **Stability** (S) and **Difficulty** (D), using a power-law forgetting curve with 21 trainable parameters. You can customize the scheduler:
+
+```python
+scheduler = FSRSScheduler(
+    request_retention=0.85,   # target retention (default: 0.9)
+    maximum_interval=365,     # max interval in days (default: 36500)
+)
+```
+
+Custom model weights (e.g., from the [FSRS optimizer](https://github.com/open-spaced-repetition/fsrs4anki)) can also be provided:
+
+```python
+scheduler = FSRSScheduler(weights=my_optimized_weights)
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spacedreppy"
-version = "0.3.0"
+version = "0.4.0"
 description = "A spaced repetition Python library."
 authors = [
     { name = "Louis Schlessinger", email = "2996982+lschlessinger1@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spacedreppy"
-version = "0.4.0"
+version = "0.5.0"
 description = "A spaced repetition Python library."
 authors = [
     { name = "Louis Schlessinger", email = "2996982+lschlessinger1@users.noreply.github.com" },

--- a/spacedreppy/__init__.py
+++ b/spacedreppy/__init__.py
@@ -2,9 +2,16 @@
 
 from importlib.metadata import version
 
+from spacedreppy.schedulers.fsrs import FSRSScheduler
 from spacedreppy.schedulers.leitner import LeitnerScheduler
 from spacedreppy.schedulers.sm2 import SM2Scheduler
 from spacedreppy.schedulers.spaced_repetition_scheduler import SpacedRepetitionScheduler
 
 __version__ = version("spacedreppy")
-__all__ = ["LeitnerScheduler", "SM2Scheduler", "SpacedRepetitionScheduler", "__version__"]
+__all__ = [
+    "FSRSScheduler",
+    "LeitnerScheduler",
+    "SM2Scheduler",
+    "SpacedRepetitionScheduler",
+    "__version__",
+]

--- a/spacedreppy/schedulers/__init__.py
+++ b/spacedreppy/schedulers/__init__.py
@@ -1,7 +1,8 @@
 """Spaced repetition scheduler implementations."""
 
+from spacedreppy.schedulers.fsrs import FSRSScheduler
 from spacedreppy.schedulers.leitner import LeitnerScheduler
 from spacedreppy.schedulers.sm2 import SM2Scheduler
 from spacedreppy.schedulers.spaced_repetition_scheduler import SpacedRepetitionScheduler
 
-__all__ = ["LeitnerScheduler", "SM2Scheduler", "SpacedRepetitionScheduler"]
+__all__ = ["FSRSScheduler", "LeitnerScheduler", "SM2Scheduler", "SpacedRepetitionScheduler"]

--- a/spacedreppy/schedulers/fsrs.py
+++ b/spacedreppy/schedulers/fsrs.py
@@ -1,0 +1,287 @@
+"""FSRS-6 (Free Spaced Repetition Scheduler) implementation.
+
+Implements the FSRS-6 algorithm which models memory with two state variables —
+Stability (S) and Difficulty (D) — using a power-law forgetting curve with
+21 trainable parameters.
+
+Reference: https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+
+from spacedreppy.schedulers.spaced_repetition_scheduler import SpacedRepetitionScheduler
+
+# Rating constants
+AGAIN = 1
+HARD = 2
+GOOD = 3
+EASY = 4
+MIN_RATING = AGAIN
+MAX_RATING = EASY
+
+# Algorithm constants
+NUM_WEIGHTS = 21
+MIN_DIFFICULTY = 1.0
+MAX_DIFFICULTY = 10.0
+MIN_STABILITY = 0.1
+
+# Default FSRS-6 parameters (21 weights)
+DEFAULT_WEIGHTS: tuple[float, ...] = (
+    0.212,
+    1.2931,
+    2.3065,
+    8.2956,
+    6.4133,
+    0.8334,
+    3.0194,
+    0.001,
+    1.8722,
+    0.1666,
+    0.796,
+    1.4835,
+    0.0614,
+    0.2629,
+    1.6483,
+    0.6014,
+    1.8729,
+    0.5425,
+    0.0912,
+    0.0658,
+    0.1542,
+)
+
+DEFAULT_REQUEST_RETENTION = 0.9
+DEFAULT_MAXIMUM_INTERVAL = 36500
+
+
+def _constrain_difficulty(d: float) -> float:
+    return min(max(d, MIN_DIFFICULTY), MAX_DIFFICULTY)
+
+
+def _initial_stability(rating: int, w: tuple[float, ...]) -> float:
+    """S0(G) = max(w[G-1], 0.1)."""
+    return max(w[rating - 1], MIN_STABILITY)
+
+
+def _initial_difficulty(rating: int, w: tuple[float, ...]) -> float:
+    """D0(G) = w[4] - exp(w[5] * (G - 1)) + 1, constrained to [1, 10]."""
+    return _constrain_difficulty(w[4] - math.exp(w[5] * (rating - 1)) + 1)
+
+
+def _forgetting_curve(elapsed_days: float, stability: float, decay: float, factor: float) -> float:
+    """R(t, S) = (1 + factor * t / S) ^ decay."""
+    return float((1 + factor * elapsed_days / stability) ** decay)
+
+
+def _linear_damping(delta_d: float, old_d: float) -> float:
+    return delta_d * (MAX_DIFFICULTY - old_d) / 9
+
+
+def _mean_reversion(init: float, current: float, w7: float) -> float:
+    return w7 * init + (1 - w7) * current
+
+
+def _next_difficulty(d: float, rating: int, w: tuple[float, ...]) -> float:
+    """Compute new difficulty after review with linear damping and mean reversion."""
+    delta_d = -w[6] * (rating - 3)
+    next_d = d + _linear_damping(delta_d, d)
+    # Mean reversion towards D0(4) (Easy) in FSRS-5+
+    d0_easy = _initial_difficulty(EASY, w)
+    return _constrain_difficulty(_mean_reversion(d0_easy, next_d, w[7]))
+
+
+def _next_recall_stability(
+    d: float, s: float, r: float, rating: int, w: tuple[float, ...]
+) -> float:
+    """S'r — new stability after successful recall (Hard, Good, or Easy)."""
+    hard_penalty = w[15] if rating == HARD else 1.0
+    easy_bonus = w[16] if rating == EASY else 1.0
+    return float(
+        s
+        * (
+            1
+            + math.exp(w[8])
+            * (11 - d)
+            * s ** (-w[9])
+            * (math.exp((1 - r) * w[10]) - 1)
+            * hard_penalty
+            * easy_bonus
+        )
+    )
+
+
+def _next_forget_stability(d: float, s: float, r: float, w: tuple[float, ...]) -> float:
+    """S'f — new stability after forgetting (Again), capped at s_min."""
+    s_min = s / math.exp(w[17] * w[18])
+    return float(
+        min(
+            w[11] * d ** (-w[12]) * ((s + 1) ** w[13] - 1) * math.exp((1 - r) * w[14]),
+            s_min,
+        )
+    )
+
+
+def _next_short_term_stability(s: float, rating: int, w: tuple[float, ...]) -> float:
+    """S'(S, G) for same-day reviews.
+
+    S' = S * e^(w17 * (G - 3 + w18)) * S^(-w19),
+    with SInc >= 1 when G >= 3.
+    """
+    s_inc = math.exp(w[17] * (rating - 3 + w[18])) * s ** (-w[19])
+    if rating >= GOOD:
+        s_inc = max(s_inc, 1.0)
+    return float(s * s_inc)
+
+
+def _next_interval(
+    stability: float,
+    request_retention: float,
+    maximum_interval: int,
+    decay: float,
+    factor: float,
+) -> int:
+    """I(r, S) = S / factor * (r^(1/decay) - 1), clamped to [1, maximum_interval]."""
+    ivl = stability / factor * (request_retention ** (1 / decay) - 1)
+    return int(min(max(round(ivl), 1), maximum_interval))
+
+
+def fsrs(
+    rating: int,
+    stability: float,
+    difficulty: float,
+    elapsed_days: float,
+    weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+    request_retention: float = DEFAULT_REQUEST_RETENTION,
+    maximum_interval: int = DEFAULT_MAXIMUM_INTERVAL,
+) -> tuple[float, float, int]:
+    """FSRS-6 algorithm.
+
+    Computes new memory states and the next review interval based on the rating.
+    Handles three scenarios based on current state:
+    - New card (stability == 0): initializes stability and difficulty.
+    - Same-day review (elapsed_days == 0, stability > 0): short-term stability update.
+    - Regular review (elapsed_days > 0, stability > 0): full stability/difficulty update.
+
+    Args:
+        rating: A grade from 1 (Again) to 4 (Easy).
+        stability: Current memory stability in days (0 for new cards).
+        difficulty: Current difficulty in [1, 10] (0 for new cards).
+        elapsed_days: Days since last review (0 for new or same-day reviews).
+        weights: Tuple of 21 FSRS-6 model weights.
+        request_retention: Target retention probability (0 < r < 1).
+        maximum_interval: Maximum allowed interval in days.
+
+    Returns:
+        A tuple of (new_stability, new_difficulty, interval_days).
+
+    Raises:
+        ValueError: If any input is out of valid range.
+    """
+    if not MIN_RATING <= rating <= MAX_RATING:
+        raise ValueError(f"rating must be between {MIN_RATING} and {MAX_RATING}, got {rating}")
+    if stability < 0:
+        raise ValueError(f"stability must be non-negative, got {stability}")
+    if elapsed_days < 0:
+        raise ValueError(f"elapsed_days must be non-negative, got {elapsed_days}")
+    if len(weights) != NUM_WEIGHTS:
+        raise ValueError(f"weights must have {NUM_WEIGHTS} elements, got {len(weights)}")
+    if not 0 < request_retention < 1:
+        raise ValueError(
+            f"request_retention must be between 0 and 1 exclusive, got {request_retention}"
+        )
+    if maximum_interval <= 0:
+        raise ValueError(f"maximum_interval must be positive, got {maximum_interval}")
+
+    w = weights
+    decay = -w[20]
+    factor = 0.9 ** (1 / decay) - 1
+
+    if stability == 0:
+        # New card
+        new_s = _initial_stability(rating, w)
+        new_d = _initial_difficulty(rating, w)
+    elif elapsed_days == 0:
+        # Same-day review
+        new_s = _next_short_term_stability(stability, rating, w)
+        new_d = _next_difficulty(difficulty, rating, w)
+    else:
+        # Regular review
+        r = _forgetting_curve(elapsed_days, stability, decay, factor)
+        new_d = _next_difficulty(difficulty, rating, w)
+        if rating == AGAIN:
+            new_s = _next_forget_stability(difficulty, stability, r, w)
+        else:
+            new_s = _next_recall_stability(difficulty, stability, r, rating, w)
+
+    interval = _next_interval(new_s, request_retention, maximum_interval, decay, factor)
+    return new_s, new_d, interval
+
+
+class FSRSScheduler(SpacedRepetitionScheduler):
+    """Spaced repetition scheduler using the FSRS-6 algorithm.
+
+    Args:
+        stability: Current memory stability in days. Defaults to 0 (new card).
+        difficulty: Current difficulty. Defaults to 0 (new card).
+        weights: Tuple of 21 FSRS-6 model weights.
+        request_retention: Target retention probability. Defaults to 0.9.
+        maximum_interval: Maximum allowed interval in days. Defaults to 36500.
+        interval: The current interval in days. Defaults to 0.
+    """
+
+    def __init__(
+        self,
+        stability: float = 0.0,
+        difficulty: float = 0.0,
+        weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+        request_retention: float = DEFAULT_REQUEST_RETENTION,
+        maximum_interval: int = DEFAULT_MAXIMUM_INTERVAL,
+        interval: int = 0,
+    ) -> None:
+        super().__init__(interval=interval)
+        self.stability = stability
+        self.difficulty = difficulty
+        self.weights = weights
+        self.request_retention = request_retention
+        self.maximum_interval = maximum_interval
+        self.last_review_at: datetime | None = None
+
+    def _compute_next_due_interval(
+        self, attempted_at: datetime, result: int
+    ) -> tuple[datetime, timedelta]:
+        """Calculate the next due timestamp and interval.
+
+        Args:
+            attempted_at: The timestamp of the review attempt.
+            result: Rating from 1 (Again) to 4 (Easy).
+
+        Returns:
+            A tuple of the next due timestamp and the interval timedelta.
+        """
+        if self.last_review_at is not None:
+            elapsed_days = max((attempted_at - self.last_review_at).days, 0)
+        else:
+            elapsed_days = 0
+
+        new_s, new_d, interval_days = fsrs(
+            rating=result,
+            stability=self.stability,
+            difficulty=self.difficulty,
+            elapsed_days=elapsed_days,
+            weights=self.weights,
+            request_retention=self.request_retention,
+            maximum_interval=self.maximum_interval,
+        )
+
+        self.stability = new_s
+        self.difficulty = new_d
+        self.interval = interval_days
+        self.last_review_at = attempted_at
+
+        new_timedelta_interval = timedelta(days=self.interval)
+        prev_start_timestamp = self.due_timestamp if self.due_timestamp else attempted_at
+        due_timestamp = prev_start_timestamp + new_timedelta_interval
+        return due_timestamp, new_timedelta_interval

--- a/tests/test_fsrs.py
+++ b/tests/test_fsrs.py
@@ -1,0 +1,290 @@
+import datetime
+
+import pytest
+
+from spacedreppy.schedulers.fsrs import (
+    AGAIN,
+    DEFAULT_MAXIMUM_INTERVAL,
+    DEFAULT_REQUEST_RETENTION,
+    DEFAULT_WEIGHTS,
+    EASY,
+    GOOD,
+    HARD,
+    FSRSScheduler,
+    fsrs,
+)
+from spacedreppy.schedulers.spaced_repetition_scheduler import SpacedRepetitionScheduler
+
+
+@pytest.fixture
+def scheduler() -> FSRSScheduler:
+    return FSRSScheduler()
+
+
+def test_fsrs_return_types():
+    stability, difficulty, interval = fsrs(rating=GOOD, stability=0, difficulty=0, elapsed_days=0)
+    assert isinstance(stability, float)
+    assert isinstance(difficulty, float)
+    assert isinstance(interval, int)
+
+
+@pytest.mark.parametrize(
+    "rating, expected_stability, expected_difficulty, expected_interval",
+    [
+        (AGAIN, 0.212, 6.4133, 1),
+        (HARD, 1.2931, 5.112170705601055, 1),
+        (GOOD, 2.3065, 2.118103970459015, 2),
+        (EASY, 8.2956, 1.0, 8),
+    ],
+)
+def test_fsrs_new_card(
+    rating: int,
+    expected_stability: float,
+    expected_difficulty: float,
+    expected_interval: int,
+) -> None:
+    stability, difficulty, interval = fsrs(rating=rating, stability=0, difficulty=0, elapsed_days=0)
+    assert stability == pytest.approx(expected_stability)
+    assert difficulty == pytest.approx(expected_difficulty)
+    assert interval == expected_interval
+
+
+@pytest.mark.parametrize(
+    "rating, elapsed_days, expected_stability, expected_difficulty, expected_interval",
+    [
+        # New Good -> 2d Good
+        (GOOD, 2, 10.964332335820703, 2.1169858664885557, 11),
+        # New Good -> 2d Again (forget path)
+        (AGAIN, 2, 0.6075801062519337, 7.40027437198288, 1),
+    ],
+)
+def test_fsrs_review_after_new_good(
+    rating: int,
+    elapsed_days: int,
+    expected_stability: float,
+    expected_difficulty: float,
+    expected_interval: int,
+) -> None:
+    # First: new card with Good
+    s0 = 2.3065
+    d0 = 2.118103970459015
+    stability, difficulty, interval = fsrs(
+        rating=rating, stability=s0, difficulty=d0, elapsed_days=elapsed_days
+    )
+    assert stability == pytest.approx(expected_stability)
+    assert difficulty == pytest.approx(expected_difficulty)
+    assert interval == expected_interval
+
+
+def test_fsrs_review_after_new_easy_hard():
+    # New Easy -> 8d Hard
+    s0, d0 = 8.2956, 1.0
+    stability, difficulty, interval = fsrs(rating=HARD, stability=s0, difficulty=d0, elapsed_days=8)
+    assert stability == pytest.approx(26.704183359371367)
+    assert difficulty == pytest.approx(4.016380600000001)
+    assert interval == 27
+
+
+def test_fsrs_same_day_review():
+    # New Again -> same-day Good
+    s0, d0 = 0.212, 6.4133
+    stability, difficulty, interval = fsrs(rating=GOOD, stability=s0, difficulty=d0, elapsed_days=0)
+    assert stability == pytest.approx(0.24668918777567272)
+    assert difficulty == pytest.approx(6.4078867)
+    assert interval == 1
+
+
+@pytest.mark.parametrize(
+    "rating, expected_stability",
+    [
+        (AGAIN, 0.08335671711031603),
+        (HARD, 0.14339874769184835),
+        (GOOD, 0.24668918777567272),
+        (EASY, 0.42437996387663374),
+    ],
+)
+def test_fsrs_same_day_all_ratings(rating: int, expected_stability: float) -> None:
+    s0, d0 = 0.212, 6.4133
+    stability, _difficulty, _interval = fsrs(
+        rating=rating, stability=s0, difficulty=d0, elapsed_days=0
+    )
+    assert stability == pytest.approx(expected_stability)
+
+
+def test_fsrs_three_step_sequence():
+    # New Good -> 2d Good -> 11d Easy
+    s, d, _ = fsrs(rating=GOOD, stability=0, difficulty=0, elapsed_days=0)
+    s, d, _ = fsrs(rating=GOOD, stability=s, difficulty=d, elapsed_days=2)
+    s, d, ivl = fsrs(rating=EASY, stability=s, difficulty=d, elapsed_days=11)
+    assert s == pytest.approx(77.06450547606927)
+    assert d == pytest.approx(1.0)
+    assert ivl == 77
+
+
+def test_fsrs_difficulty_clamped_at_max():
+    # Repeated Again ratings should push difficulty towards max but never exceed 10
+    s, d, _ = fsrs(rating=AGAIN, stability=0, difficulty=0, elapsed_days=0)
+    for _ in range(20):
+        s, d, _ = fsrs(rating=AGAIN, stability=s, difficulty=d, elapsed_days=0)
+    assert d <= 10.0
+    assert d >= 1.0
+
+
+def test_fsrs_difficulty_clamped_at_min():
+    # Repeated Easy ratings should push difficulty towards min but never below 1
+    s, d, _ = fsrs(rating=EASY, stability=0, difficulty=0, elapsed_days=0)
+    assert d == 1.0
+    for _ in range(20):
+        s, d, _ = fsrs(rating=EASY, stability=s, difficulty=d, elapsed_days=0)
+    assert d >= 1.0
+
+
+def test_fsrs_interval_clamped_to_maximum():
+    _stability, _, interval = fsrs(
+        rating=GOOD, stability=0, difficulty=0, elapsed_days=0, maximum_interval=1
+    )
+    assert interval == 1
+
+
+def test_fsrs_interval_at_least_one():
+    _stability, _, interval = fsrs(rating=AGAIN, stability=0, difficulty=0, elapsed_days=0)
+    assert interval >= 1
+
+
+@pytest.mark.parametrize(
+    "rating, stability, difficulty, elapsed_days",
+    [
+        (0, 0, 0, 0),  # rating too low
+        (5, 0, 0, 0),  # rating too high
+        (GOOD, -1, 0, 0),  # negative stability
+        (GOOD, 0, 0, -1),  # negative elapsed_days
+    ],
+)
+def test_fsrs_invalid_inputs(
+    rating: int, stability: float, difficulty: float, elapsed_days: float
+) -> None:
+    with pytest.raises(ValueError):
+        fsrs(
+            rating=rating,
+            stability=stability,
+            difficulty=difficulty,
+            elapsed_days=elapsed_days,
+        )
+
+
+def test_fsrs_invalid_weights_length():
+    with pytest.raises(ValueError, match="weights must have 21 elements"):
+        fsrs(rating=GOOD, stability=0, difficulty=0, elapsed_days=0, weights=(1.0, 2.0))
+
+
+def test_fsrs_invalid_request_retention():
+    with pytest.raises(ValueError, match="request_retention"):
+        fsrs(rating=GOOD, stability=0, difficulty=0, elapsed_days=0, request_retention=0.0)
+    with pytest.raises(ValueError, match="request_retention"):
+        fsrs(rating=GOOD, stability=0, difficulty=0, elapsed_days=0, request_retention=1.0)
+
+
+def test_fsrs_invalid_maximum_interval():
+    with pytest.raises(ValueError, match="maximum_interval"):
+        fsrs(rating=GOOD, stability=0, difficulty=0, elapsed_days=0, maximum_interval=0)
+
+
+# --- FSRSScheduler tests ---
+
+
+def test_scheduler_is_spaced_repetition_scheduler(scheduler: FSRSScheduler) -> None:
+    assert isinstance(scheduler, SpacedRepetitionScheduler)
+
+
+def test_scheduler_initialization_defaults(scheduler: FSRSScheduler) -> None:
+    assert scheduler.stability == 0.0
+    assert scheduler.difficulty == 0.0
+    assert scheduler.interval == 0
+    assert scheduler.weights == DEFAULT_WEIGHTS
+    assert scheduler.request_retention == DEFAULT_REQUEST_RETENTION
+    assert scheduler.maximum_interval == DEFAULT_MAXIMUM_INTERVAL
+    assert scheduler.due_timestamp is None
+    assert scheduler.last_review_at is None
+
+
+def test_scheduler_custom_weights():
+    custom_w = tuple(float(i) for i in range(21))
+    s = FSRSScheduler(weights=custom_w)
+    assert s.weights == custom_w
+
+
+@pytest.mark.parametrize(
+    "rating, expected_stability, expected_difficulty, expected_interval",
+    [
+        (AGAIN, 0.212, 6.4133, 1),
+        (HARD, 1.2931, 5.112170705601055, 1),
+        (GOOD, 2.3065, 2.118103970459015, 2),
+        (EASY, 8.2956, 1.0, 8),
+    ],
+)
+def test_scheduler_compute_next_due_interval_once(
+    scheduler: FSRSScheduler,
+    rating: int,
+    expected_stability: float,
+    expected_difficulty: float,
+    expected_interval: int,
+) -> None:
+    attempted_at = datetime.datetime.now(datetime.UTC)
+    due_timestamp, interval_td = scheduler.compute_next_due_interval(
+        attempted_at=attempted_at, result=rating
+    )
+    assert isinstance(due_timestamp, datetime.datetime)
+    assert isinstance(interval_td, datetime.timedelta)
+    assert due_timestamp == scheduler.due_timestamp
+    assert interval_td == scheduler.interval_td
+    assert interval_td == datetime.timedelta(days=expected_interval)
+    assert scheduler.stability == pytest.approx(expected_stability)
+    assert scheduler.difficulty == pytest.approx(expected_difficulty)
+    assert scheduler.due_timestamp == attempted_at + datetime.timedelta(days=expected_interval)
+    assert scheduler.last_review_at == attempted_at
+
+
+def test_scheduler_compute_next_due_interval_twice(scheduler: FSRSScheduler) -> None:
+    attempted_at_1 = datetime.datetime(year=2025, month=1, day=1, tzinfo=datetime.UTC)
+    attempted_at_2 = datetime.datetime(year=2025, month=1, day=3, tzinfo=datetime.UTC)
+
+    due_1, _ = scheduler.compute_next_due_interval(attempted_at=attempted_at_1, result=GOOD)
+    due_2, interval_2 = scheduler.compute_next_due_interval(
+        attempted_at=attempted_at_2, result=GOOD
+    )
+
+    assert isinstance(due_2, datetime.datetime)
+    assert isinstance(interval_2, datetime.timedelta)
+    assert scheduler.stability == pytest.approx(10.964332335820703)
+    assert scheduler.difficulty == pytest.approx(2.1169858664885557)
+    assert interval_2 == datetime.timedelta(days=11)
+    assert scheduler.due_timestamp == due_1 + datetime.timedelta(days=11)
+
+
+def test_scheduler_compute_next_due_interval_thrice(scheduler: FSRSScheduler) -> None:
+    at1 = datetime.datetime(year=2025, month=1, day=1, tzinfo=datetime.UTC)
+    at2 = datetime.datetime(year=2025, month=1, day=3, tzinfo=datetime.UTC)
+    at3 = datetime.datetime(year=2025, month=1, day=14, tzinfo=datetime.UTC)
+
+    scheduler.compute_next_due_interval(attempted_at=at1, result=GOOD)
+    scheduler.compute_next_due_interval(attempted_at=at2, result=GOOD)
+    due_3, interval_3 = scheduler.compute_next_due_interval(attempted_at=at3, result=EASY)
+
+    assert isinstance(due_3, datetime.datetime)
+    assert isinstance(interval_3, datetime.timedelta)
+    assert scheduler.stability == pytest.approx(77.06450547606927)
+    assert scheduler.difficulty == pytest.approx(1.0)
+    assert interval_3 == datetime.timedelta(days=77)
+    assert isinstance(scheduler.interval, int)
+
+
+def test_scheduler_forget_path(scheduler: FSRSScheduler) -> None:
+    at1 = datetime.datetime(year=2025, month=1, day=1, tzinfo=datetime.UTC)
+    at2 = datetime.datetime(year=2025, month=1, day=3, tzinfo=datetime.UTC)
+
+    scheduler.compute_next_due_interval(attempted_at=at1, result=GOOD)
+    scheduler.compute_next_due_interval(attempted_at=at2, result=AGAIN)
+
+    assert scheduler.stability == pytest.approx(0.6075801062519337)
+    assert scheduler.difficulty == pytest.approx(7.40027437198288)
+    assert scheduler.interval == 1


### PR DESCRIPTION
## Summary
Add **FSRS-6 (Free Spaced Repetition Scheduler)** as a third scheduling algorithm alongside SM-2 and Leitner.

---

## Changes

### New Files
- `spacedreppy/schedulers/fsrs.py` — FSRS-6 algorithm implementation:
  - Pure `fsrs()` function with 21 FSRS-6 model weights
  - Three review paths:
    - New card
    - Same-day review
    - Regular review
  - Helper functions:
    - Forgetting curve
    - Stability updates (recall / forget / short-term)
    - Difficulty updates
    - Interval calculation
  - `FSRSScheduler` class extending `SpacedRepetitionScheduler`

- `tests/test_fsrs.py` — 35 parametrized tests covering:
  - All review paths
  - Edge cases
  - Input validation

---

### Modified Files
- `spacedreppy/schedulers/__init__.py` — added `FSRSScheduler` export  
- `spacedreppy/__init__.py` — added `FSRSScheduler` export  

---

## Algorithm

FSRS models memory with two state variables:

- **Stability (S):** Interval (in days) when retrievability = 90%  
- **Difficulty (D):** Value in `[1, 10]` reflecting item difficulty  

### Key Formulas (FSRS-6)

- **Forgetting curve:**
```

R(t, S) = (1 + factor * t / S) ^ decay

```
where `factor = w[20]`

- **Recall stability:**
```

S'r = S * (1 + e^w8 * (11 - D) * S^(-w9) *
(e^((1 - R) * w10) - 1) *
hardPenalty * easyBonus)

```

- **Forget stability:**
```

S'f = min(
w11 * D^(-w12) * ((S + 1)^w13 - 1) * e^((1 - R) * w14),
S / e^(w17 * w18)
)

```

- **Same-day stability:**
```

S' = S * e^(w17 * (G - 3 + w18)) * S^(-w19)

```

- **Rating scale:**
- 1 — Again
- 2 — Hard
- 3 — Good
- 4 — Easy

---

## Verification

- ✅ 117 tests pass (35 new + 82 existing)  
- ✅ 100% test coverage  
- ✅ `mypy` strict mode  
- ✅ `ruff` format + lint  
- ✅ `bandit` security check  

---

## References

- FSRS Algorithm Wiki  
- py-fsrs  
- FSRS Technical Explanation