### PR TITLE
fix: add PyPI publish steps to auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+    environment: pypi
     steps:
       - uses: actions/checkout@v6
 
@@ -33,3 +35,21 @@ jobs:
         run: gh release create "v${{ steps.version.outputs.version }}" --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        if: steps.check.outputs.exists == 'false'
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        if: steps.check.outputs.exists == 'false'
+        run: uv python install 3.13
+
+      - name: Build package
+        if: steps.check.outputs.exists == 'false'
+        run: uv build
+
+      - name: Publish to PyPI
+        if: steps.check.outputs.exists == 'false'
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Problem

Releases created by `auto-release.yml` use `GITHUB_TOKEN`, which does not trigger other workflows. This means `publish.yml` (triggered on `release: published`) was never fired after auto-release created a GitHub release, leaving PyPI stuck at v0.1.0 while GitHub releases advanced to v0.5.0.

## Solution

Add build and publish steps directly to `auto-release.yml` so PyPI publishing happens in the same workflow that creates the GitHub release:

- Added `id-token: write` permission for OIDC authentication
- Added `environment: pypi` for trusted publisher support
- Added uv install, Python setup, `uv build`, and `pypa/gh-action-pypi-publish` steps
- All new steps are gated with the same `if: steps.check.outputs.exists == 'false'` condition

`publish.yml` is kept as-is for manually-created releases and `workflow_dispatch` fallback.